### PR TITLE
Global DefaultOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ If you have any unsigned cookies, you can still access their values by using the
 `unsigned` tag in the struct field:
 
 ```go
-type User struct {
+type MyCookies struct {
   Debug bool `cookie:"user_id,unsigned"`
 }
 ```

--- a/README.md
+++ b/README.md
@@ -121,3 +121,55 @@ should change this signing key for your application by assigning the
 ```go
 cookie.SigningKey = []byte("my-secret-key")
 ```
+
+## Default Options
+
+You can set default options for all cookies by assigning the
+`cookie.DefaultOptions` variable:
+
+```go
+cookie.DefaultOptions = &cookie.Options{
+  Domain: "example.com",
+  Expires: time.Now().Add(24 * time.Hour),
+  MaxAge: 86400,
+  Secure: true,
+  HttpOnly: true,
+  SameSite: http.SameSiteStrictMode,
+}
+```
+
+These options will be used as the defaults for cookies that do not strictly
+override them, allowing you to only set the values you care about.
+
+### Signed by Default
+
+If you want all cookies to be signed by default, you can set the `Signed` field
+in the `cookie.DefaultOptions`:
+
+```go
+cookie.DefaultOptions = &cookie.Options{
+  Signed: true,
+}
+```
+
+Which makes all cookies signed by default.
+
+If you have any unsigned cookies, you can still access their values by using the
+`unsigned` tag in the struct field:
+
+```go
+type User struct {
+  Debug bool `cookie:"user_id,unsigned"`
+}
+```
+
+However you will need to explicitly override this value when setting the cookie,
+as the default will be to sign the cookie:
+
+```go
+cookie.Set(w, "debug", "true", &cookie.Options{
+  Signed: false,
+})
+```
+
+Due to the default value now overriding the option.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ type MyCookies struct {
 }
 ```
 
-Unsigned values can still be retrieved using the `Get` method as normal:
+Or retrieve them using the `Get` method:
 
 ```go
 debug, err := cookie.Get(r, "debug")

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ cookie.Set(w, "debug", "true", &cookie.Options{
 })
 ```
 
-When defaulting to signed cookies, you can still use the `unsigned` tag in the
-struct field to populate unsigned cookies:
+When defaulting to signed cookies, unsigned cookies can still be populated by
+using the `unsigned` tag in the struct field:
 
 ```go
 type MyCookies struct {

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ cookie.DefaultOptions = &cookie.Options{
 }
 ```
 
-Which makes all cookies signed by default.
+Which will sign all cookies by default, even when using the `Set` and `Get`
+methods.
 
 If you have any unsigned cookies, you can still access their values by using the
 `unsigned` tag in the struct field:
@@ -172,4 +173,4 @@ cookie.Set(w, "debug", "true", &cookie.Options{
 })
 ```
 
-Due to the default value now overriding the option.
+Due to the option now defaulting to `true`.

--- a/README.md
+++ b/README.md
@@ -152,20 +152,9 @@ cookie.DefaultOptions = &cookie.Options{
 }
 ```
 
-Which will sign all cookies by default, even when using the `Set` and `Get`
-methods.
-
-If you have any unsigned cookies, you can still access their values by using the
-`unsigned` tag in the struct field:
-
-```go
-type MyCookies struct {
-  Debug bool `cookie:"user_id,unsigned"`
-}
-```
-
-However you will need to explicitly override this value when setting the cookie,
-as the default will be to sign the cookie:
+Which will now sign all cookies by default when using the `Set` method. You can
+still override this by passing `Signed: false` to the options when setting a
+cookie.
 
 ```go
 cookie.Set(w, "debug", "true", &cookie.Options{
@@ -173,4 +162,13 @@ cookie.Set(w, "debug", "true", &cookie.Options{
 })
 ```
 
-Due to the option now defaulting to `true`.
+But will need to explicitly `GetSigned` when retrieving the value.
+
+When defaulting to signed cookies, you can still use the `unsigned` tag in the
+struct field to populate unsigned cookies:
+
+```go
+type MyCookies struct {
+  Debug bool `cookie:"debug,unsigned"`
+}
+```

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ type MyCookies struct {
 }
 ```
 
-Or retrieve them using the `Get` method:
+Or retrieve unsigned cookies using the `Get` method:
 
 ```go
 debug, err := cookie.Get(r, "debug")

--- a/README.md
+++ b/README.md
@@ -162,13 +162,21 @@ cookie.Set(w, "debug", "true", &cookie.Options{
 })
 ```
 
-But will need to explicitly `GetSigned` when retrieving the value.
-
 When defaulting to signed cookies, you can still use the `unsigned` tag in the
 struct field to populate unsigned cookies:
 
 ```go
 type MyCookies struct {
   Debug bool `cookie:"debug,unsigned"`
+}
+```
+
+Unsigned values can still be retrieved using the `Get` method as normal:
+
+```go
+debug, err := cookie.Get(r, "debug")
+if err != nil {
+  http.Error(w, err.Error(), http.StatusInternalServerError)
+  return
 }
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ import (
 type MyCookies struct {
   Debug bool `cookie:"DEBUG"`
 }
+
 ...
 
 var cookies Cookies

--- a/_example/main.go
+++ b/_example/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/syntaqx/cookie"
 )
 
-type AccessTokenRequest struct {
+type RequestCookies struct {
 	ApplicationID uuid.UUID `cookie:"Application-ID"`
 	AccessToken   string    `cookie:"Access-Token,signed"`
 	UserID        int       `cookie:"User-ID,signed"`
@@ -31,7 +31,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Populate struct from cookies
-	var req AccessTokenRequest
+	var req RequestCookies
 	err = cookie.PopulateFromCookies(r, &req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -39,7 +39,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Dump the struct as a response
-	fmt.Fprintf(w, "AccessTokenRequest: %+v", req)
+	fmt.Fprintf(w, "RequestCookies: %+v", req)
 }
 
 func setDemoCookies(w http.ResponseWriter) {

--- a/cookie.go
+++ b/cookie.go
@@ -168,8 +168,17 @@ func PopulateFromCookies(r *http.Request, dest interface{}) error {
 
 		var cookie string
 		var err error
+		isSigned := DefaultOptions.Signed
 
-		if len(tagParts) > 1 && tagParts[1] == "signed" {
+		for _, part := range tagParts[1:] {
+			if part == "signed" {
+				isSigned = true
+			} else if part == "unsigned" {
+				isSigned = false
+			}
+		}
+
+		if isSigned {
 			cookie, err = GetSigned(r, tagParts[0])
 		} else {
 			cookie, err = Get(r, tagParts[0])

--- a/cookie.go
+++ b/cookie.go
@@ -22,10 +22,22 @@ const (
 var (
 	// SigningKey is the key used to sign cookies.
 	SigningKey = []byte(DefaultSigningKey)
+
+	// DefaultOptions are the default options for cookies.
+	DefaultOptions = &Options{
+		Path:     "/",
+		Domain:   "",
+		Expires:  time.Time{},
+		MaxAge:   0,
+		Secure:   false,
+		HttpOnly: false,
+		SameSite: http.SameSiteDefaultMode,
+		Signed:   false,
+	}
 )
 
 var (
-	// UnsupportedTypeError is returned when a field type is not supported by PopulateFromCookies.
+	// ErrUnsupportedType is returned when a field type is not supported by PopulateFromCookies.
 	ErrUnsupportedType = errors.New("cookie: unsupported type")
 
 	// ErrInvalidSignedCookieFormat is returned when a signed cookie is not in the correct format.
@@ -55,22 +67,20 @@ type Options struct {
 
 // Set sets a cookie with the given name, value, and options.
 func Set(w http.ResponseWriter, name, value string, options *Options) {
-	if options == nil {
-		options = &Options{}
-	}
+	mergedOptions := mergeOptions(options, DefaultOptions)
 	cookie := &http.Cookie{
 		Name:     name,
 		Value:    value,
-		Path:     options.Path,
-		Domain:   options.Domain,
-		Expires:  options.Expires,
-		MaxAge:   options.MaxAge,
-		Secure:   options.Secure,
-		HttpOnly: options.HttpOnly,
-		SameSite: options.SameSite,
+		Path:     mergedOptions.Path,
+		Domain:   mergedOptions.Domain,
+		Expires:  mergedOptions.Expires,
+		MaxAge:   mergedOptions.MaxAge,
+		Secure:   mergedOptions.Secure,
+		HttpOnly: mergedOptions.HttpOnly,
+		SameSite: mergedOptions.SameSite,
 	}
 
-	if options.Signed {
+	if mergedOptions.Signed {
 		signature := generateHMAC(value)
 		cookie.Value = base64.URLEncoding.EncodeToString([]byte(value)) + "|" + signature
 	}
@@ -229,4 +239,39 @@ func generateHMAC(value string) string {
 	h := hmac.New(sha256.New, SigningKey)
 	h.Write([]byte(value))
 	return base64.URLEncoding.EncodeToString(h.Sum(nil))
+}
+
+func mergeOptions(provided, defaults *Options) *Options {
+	if provided == nil {
+		return defaults
+	}
+
+	merged := *defaults
+
+	if provided.Path != "" {
+		merged.Path = provided.Path
+	}
+	if provided.Domain != "" {
+		merged.Domain = provided.Domain
+	}
+	if !provided.Expires.IsZero() {
+		merged.Expires = provided.Expires
+	}
+	if provided.MaxAge != 0 {
+		merged.MaxAge = provided.MaxAge
+	}
+	if provided.Secure {
+		merged.Secure = provided.Secure
+	}
+	if provided.HttpOnly {
+		merged.HttpOnly = provided.HttpOnly
+	}
+	if provided.SameSite != http.SameSiteDefaultMode {
+		merged.SameSite = provided.SameSite
+	}
+	if provided.Signed {
+		merged.Signed = provided.Signed
+	}
+
+	return &merged
 }

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -69,6 +69,27 @@ func TestSet(t *testing.T) {
 	}
 }
 
+func TestSet_WithoutOptions(t *testing.T) {
+	_, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+
+	name := "myCookie"
+	value := "myValue"
+
+	Set(w, name, value, nil)
+
+	// Get the response cookies
+	cookies := w.Result().Cookies()
+
+	// Check if the cookie was set correctly
+	if len(cookies) != 1 {
+		t.Errorf("Expected 1 cookie, got %d", len(cookies))
+	}
+}
+
 func TestSetSigned(t *testing.T) {
 	_, err := http.NewRequest(http.MethodGet, "/", nil)
 	if err != nil {

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -275,6 +275,7 @@ func TestPopulateFromCookies(t *testing.T) {
 		"myIntSliceCookie": "1,2,3",
 		"myUUIDCookie":     uuid.Must(uuid.NewV4()).String(),
 		"myTimeCookie":     time.Now().Format(time.RFC3339),
+		"unsignedCookie":   "unsignedValue",
 	}
 	for name, value := range cookies {
 		r.AddCookie(&http.Cookie{
@@ -289,15 +290,16 @@ func TestPopulateFromCookies(t *testing.T) {
 	})
 
 	type MyStruct struct {
-		StringField  string    `cookie:"myCookie"`
-		IntField     int       `cookie:"myIntCookie"`
-		BoolField    bool      `cookie:"myBoolCookie"`
-		StringSlice  []string  `cookie:"mySliceCookie"`
-		IntSlice     []int     `cookie:"myIntSliceCookie"`
-		UUIDField    uuid.UUID `cookie:"myUUIDCookie"`
-		TimeField    time.Time `cookie:"myTimeCookie"`
-		SignedCookie string    `cookie:"signedCookie,signed"`
-		Unsupported  complex64 `cookie:""`
+		StringField    string    `cookie:"myCookie"`
+		IntField       int       `cookie:"myIntCookie"`
+		BoolField      bool      `cookie:"myBoolCookie"`
+		StringSlice    []string  `cookie:"mySliceCookie"`
+		IntSlice       []int     `cookie:"myIntSliceCookie"`
+		UUIDField      uuid.UUID `cookie:"myUUIDCookie"`
+		TimeField      time.Time `cookie:"myTimeCookie"`
+		UnsignedCookie string    `cookie:"unsignedCookie,unsigned"`
+		SignedCookie   string    `cookie:"signedCookie,signed"`
+		Unsupported    complex64 `cookie:""`
 	}
 
 	dest := &MyStruct{}
@@ -342,6 +344,11 @@ func TestPopulateFromCookies(t *testing.T) {
 	expectedTime, _ := time.Parse(time.RFC3339, cookies["myTimeCookie"])
 	if !dest.TimeField.Equal(expectedTime) {
 		t.Errorf("Expected TimeField %v, got %v", expectedTime, dest.TimeField)
+	}
+
+	expectedUnsignedValue := "unsignedValue"
+	if dest.UnsignedCookie != expectedUnsignedValue {
+		t.Errorf("Expected UnsignedCookie %s, got %s", expectedUnsignedValue, dest.UnsignedCookie)
 	}
 
 	expectedSignedValue := "signedValue"

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -69,27 +69,6 @@ func TestSet(t *testing.T) {
 	}
 }
 
-func TestSet_WithoutOptions(t *testing.T) {
-	_, err := http.NewRequest(http.MethodGet, "/", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	w := httptest.NewRecorder()
-
-	name := "myCookie"
-	value := "myValue"
-
-	Set(w, name, value, nil)
-
-	// Get the response cookies
-	cookies := w.Result().Cookies()
-
-	// Check if the cookie was set correctly
-	if len(cookies) != 1 {
-		t.Errorf("Expected 1 cookie, got %d", len(cookies))
-	}
-}
-
 func TestSetSigned(t *testing.T) {
 	_, err := http.NewRequest(http.MethodGet, "/", nil)
 	if err != nil {


### PR DESCRIPTION
The intent of this is to enable you to globally set `DefaultOptions` so that it's not strictly necessary to set them across usages of `cookie.Set`

Additionally, this should allow for use of `signed` to be true by default.

## TODO

- [x] This requires `PopulateFromCookies` to be able to understand `unsigned` as well when the default value is signed.
- [x] Validate that the default options are the same as the `net/http` package

Open to feedback during early stages of this PR.